### PR TITLE
Adjust spell checker configuration to fix false positive

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,7 +3,7 @@
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
 ignore-words-list = licence,ot
-skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
+skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock,*.svg
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =
 check-hidden =


### PR DESCRIPTION
The [**codespell**](https://github.com/codespell-project/codespell) tool is used for automated detection of common misspellings in the files of this project.

A new release of codespell includes an expansion of its misspellings dictionary. It now detects several misspelled words in the SVG files in the repository:

https://github.com/per1234/.github/actions/runs/6398748198/job/17369532545#step:4:17

```text
Error: ./workflow-templates/snake.svg:102: Greyscale ==> Grayscale
Error: ./workflow-templates/javascript.svg:6: Manuel ==> Manual
```

Those files are not maintained in this repository so it is better to configure **codespell** to ignore them altogether, which is done by adding the `.svg` file extension to the list of files to skip in [the codespell configuration](https://github.com/codespell-project/codespell#using-a-config-file).