### PR TITLE
Migrate workflows from deprecated set-output commands

### DIFF
--- a/.github/workflows/check-markdown.yml
+++ b/.github/workflows/check-markdown.yml
@@ -59,7 +59,7 @@ jobs:
         id: check-modified
         if: github.event_name == 'pull_request'
         run: |
-          echo "::set-output name=value::yes"
+          echo "value=yes" >> "$GITHUB_OUTPUT"
 
       - name: Check links
         uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -109,7 +109,7 @@ jobs:
         run: |
           # Use of this flag in the github-label-sync command will cause it to only check the validity of the
           # configuration.
-          echo "::set-output name=flag::--dry-run"
+          echo "flag=--dry-run" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/workflow-templates/check-markdown.yml
+++ b/workflow-templates/check-markdown.yml
@@ -59,7 +59,7 @@ jobs:
         id: check-modified
         if: github.event_name == 'pull_request'
         run: |
-          echo "::set-output name=value::yes"
+          echo "value=yes" >> "$GITHUB_OUTPUT"
 
       - name: Check links
         uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/workflow-templates/check-tsconfig.yml
+++ b/workflow-templates/check-tsconfig.yml
@@ -45,7 +45,7 @@ jobs:
           mkdir -p "$OUTPUT_FOLDER"
           OUTPUT_PATH="${OUTPUT_FOLDER}/$(basename ${{ matrix.file }})"
           strip-json-comments --no-whitespace "${{ matrix.file }}" > "$OUTPUT_PATH"
-          echo "::set-output name=output-path::$OUTPUT_PATH"
+          echo "output-path=$OUTPUT_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Download JSON schema for tsconfig.json
         id: download-schema


### PR DESCRIPTION
GitHub Actions provides the capability for workflow authors to use the capabilities of the GitHub Actions ToolKit package directly in the `run` keys of workflows via "[workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions)". One such command is `set-output`, which allows data to be passed out of a workflow step as an output.

It has been determined that this command has potential to be a security risk in some applications. For this reason, GitHub has deprecated the command and a warning of this is shown in the workflow run summary page of any workflow using it:

The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The identical capability is now provided in a safer form via the GitHub Actions "[environment files](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files)" system. Migrating the use of the deprecated workflow commands to use the `GITHUB_OUTPUT` environment file instead fixes any potential vulnerabilities in the workflows, resolves the warnings, and avoids the eventual complete breakage of the workflows that would result from [GitHub's planned removal of the `set-output` workflow command](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#:~:text=fully%20disable%20them%20on%2031st%20May%202023.).
